### PR TITLE
Use internal OC TAR to unpack archive

### DIFF
--- a/lib/Service/UtilsService.php
+++ b/lib/Service/UtilsService.php
@@ -29,6 +29,7 @@ declare(strict_types=1);
 namespace OCA\Cloud_Py_API\Service;
 
 use bantu\IniGetWrapper\IniGetWrapper;
+use OC\Archive\TAR;
 use OCP\IConfig;
 use OCP\App\IAppManager;
 
@@ -408,12 +409,10 @@ class UtilsService {
 		if (isset($binariesFolder['success']) && $binariesFolder['success']) {
 			$dir = $binariesFolder['path'] . '/';
 			$src_file = $dir . $src_filename;
-			$phar = new \PharData($src_file);
-			$extracted = $phar->extractTo($dir, null, true);
-			$filename = $phar->getFilename();
+			$archive = new TAR($src_file);
+			$extracted = $archive->extract($dir);
 			return [
 				'extracted' => $extracted,
-				'filename' => $filename
 			];
 		}
 		return [

--- a/lib/Service/UtilsService.php
+++ b/lib/Service/UtilsService.php
@@ -198,7 +198,7 @@ class UtilsService {
 
 	public function isMuslLinux(): bool {
 		exec('ldd --version 2>&1', $output, $result_code);
-		if (count($output) > 0 && str_contains($output[0], 'musl')) {
+		if (count($output) > 0 && strpos($output[0], 'musl') !== false) {
 			return true;
 		}
 		return false;
@@ -210,11 +210,11 @@ class UtilsService {
 	public function getOsArch(): string {
 		$arm64_names = ["aarch64", "armv8", "arm64"];
 		$machineType = php_uname('m');
-		if (str_contains($machineType, 'x86_64')) {
+		if (strpos($machineType, 'x86_64') !== false) {
 			return 'amd64';
 		}
 		foreach ($arm64_names as $arm64_name) {
-			if (str_contains($machineType, $arm64_name)) {
+			if (strpos($machineType, $arm64_name) !== false) {
 				return 'arm64';
 			}
 		}

--- a/tests/psalm-baseline.xml
+++ b/tests/psalm-baseline.xml
@@ -37,18 +37,14 @@
     <RedundantCondition occurrences="1">
       <code>isset($setting)</code>
     </RedundantCondition>
-    <UndefinedClass occurrences="1">
+    <UndefinedClass occurrences="2">
       <code>?DatabaseStatistics</code>
+      <code>TAR</code>
     </UndefinedClass>
     <UndefinedDocblockClass occurrences="2">
       <code>$this-&gt;databaseStatistics</code>
       <code>DatabaseStatistics</code>
     </UndefinedDocblockClass>
-    <UndefinedFunction occurrences="3">
-      <code>str_contains($machineType, $arm64_name)</code>
-      <code>str_contains($machineType, 'x86_64')</code>
-      <code>str_contains($output[0], 'musl')</code>
-    </UndefinedFunction>
     <UndefinedMagicMethod occurrences="4">
       <code>getValue</code>
       <code>getValue</code>


### PR DESCRIPTION
Resolves: https://github.com/cloud-py-api/mediadc/issues/151

Fixes usage of `str_contains` function, available only from PHP8, changed to `strpos` function.